### PR TITLE
fix: fix input layout and date picker styling

### DIFF
--- a/src/Stockly.Client/src/components/FormField.tsx
+++ b/src/Stockly.Client/src/components/FormField.tsx
@@ -25,7 +25,7 @@ export function FormField({
 
   return (
     <FieldWrapper label={label} className={className}>
-      <div className="relative">
+      <div className="relative min-w-0">
         <input
           ref={inputRef}
           type={type}
@@ -36,9 +36,9 @@ export function FormField({
               inputRef.current.showPicker();
             }
           }}
-          className={`w-full border border-stone-300 rounded-lg px-3 py-2 text-sm outline-none ${
+          className={`w-full border border-stone-300 rounded-lg px-3 py-2 text-sm outline-none box-border ${
             isDate
-              ? "[&::-webkit-calendar-picker-indicator]:hidden" // hide native calendar icon
+              ? "[-webkit-appearance:none] [&::-webkit-calendar-picker-indicator]:hidden" // iOS styling + hide native calendar icon
               : ""
           }`}
           placeholder={placeholder}

--- a/src/Stockly.Client/src/components/SearchInput.tsx
+++ b/src/Stockly.Client/src/components/SearchInput.tsx
@@ -10,10 +10,10 @@ interface SearchInputProps {
 
 export function SearchInput({ value, onChange, placeholder = 'Rechercher...', className = '' }: SearchInputProps) {
     return (
-        <div className={`flex items-center border border-stone-300 rounded-lg px-3 py-2 gap-2 bg-cream ${className}`}>
+        <div className={`flex items-center border border-stone-300 rounded-lg px-3 py-2 gap-2 bg-cream min-w-0 ${className}`}>
             <FontAwesomeIcon icon={faMagnifyingGlass} className="text-stone-400" />
             <input
-                className="flex-1 outline-none text-sm bg-transparent"
+                className="flex-1 min-w-0 outline-none text-sm bg-transparent"
                 placeholder={placeholder}
                 value={value}
                 onChange={(e) => onChange(e.target.value)}

--- a/src/Stockly.Client/src/components/admin/DaysInput.tsx
+++ b/src/Stockly.Client/src/components/admin/DaysInput.tsx
@@ -16,7 +16,7 @@ function parseNullableInt(value: string): number | null {
 export function DaysInput({ label, value, onChange }: DaysInputProps) {
     return (
         <FieldWrapper label={label}>
-            <div className="relative">
+            <div className="relative min-w-0">
                 <input
                     type="number"
                     min="0"


### PR DESCRIPTION
Add min-w-0 to input wrappers and inputs to prevent overflow in flex layouts (FormField, SearchInput, DaysInput). Also add box-border for consistent sizing and apply -webkit-appearance:none plus hiding the webkit calendar picker indicator to improve date input appearance on iOS. Files changed: FormField.tsx, SearchInput.tsx, admin/DaysInput.tsx.


closes #77
