### PR TITLE
feat: update label format

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -14,7 +14,7 @@ fi
 
 echo "Démarrage de l'API et PostgreSQL..."
 cd "$PROJECT_ROOT"
-docker compose up -d
+docker compose up --build -d
 
 echo "Attente du démarrage complet..."
 sleep 3

--- a/src/Stockly.Application/Services/PrinterService.cs
+++ b/src/Stockly.Application/Services/PrinterService.cs
@@ -11,7 +11,7 @@ public class PrinterService(IPrinterRepository repository, IPrintingService prin
     // Brother QL series standard label formats
     private static readonly IReadOnlyList<(string Name, decimal WidthMm, decimal HeightMm)> BrotherQlFormats =
     [
-        ("DK-11209 – 62×29mm", 62, 29),
+        ("TZE251 - 62x24mm", 62, 24),
         // other format will come as needed...
     ];
 


### PR DESCRIPTION
Add --build to docker compose up in start-dev.sh so development start rebuilds images before bringing services up. Update Brother QL formats in PrinterService: replace DK-11209 (62×29mm) with TZE251 (62x24mm) and adjust dimensions accordingly.


closes #85 
